### PR TITLE
Added  setuptools in req.txt as it is missing from Python3.12

### DIFF
--- a/req.txt
+++ b/req.txt
@@ -4,6 +4,7 @@ undetected-chromedriver
 Flask
 flask-restful
 Flask-AutoIndex
+setuptools
 
 ngrok
 firebase_admin


### PR DESCRIPTION
distutils package is removed in Python version 3.12 so we need:
 pip install setuptools
 setuptools has been aaded in req.txt .