### PR TITLE
fix(chrome_driver --> path, version): resolve starting Chrome on 64-bit and get_download_version 

### DIFF
--- a/chrome_d_download.py
+++ b/chrome_d_download.py
@@ -36,6 +36,8 @@ def get_download_version(c_version):
         if curr_version != None:
             if front_version_extractor(c_version) == front_version_extractor(curr_version):
                 return str(curr_version[:-1])
+            else:
+                return str(c_version)
     
 def json_version_extractor(vrsn):
     r = requests.get("https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json")

--- a/chrome_handler.py
+++ b/chrome_handler.py
@@ -6,12 +6,24 @@ import platform
 
 def get_chrome_path():
     os_name = platform.system().lower()
+    
     if os_name == "darwin":
         return "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    
     elif os_name == "windows":
-        return "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"
+        chrome_32bit_path = "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"
+        chrome_64bit_path = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+
+        if os.path.exists(chrome_32bit_path):
+            return chrome_32bit_path
+        elif os.path.exists(chrome_64bit_path):
+            return chrome_64bit_path
+        else:
+            raise FileNotFoundError("Chrome executable not found in either 32-bit or 64-bit directories.")
+    
     elif os_name == "linux":
         return "/usr/bin/google-chrome"
+    
     else:
         raise Exception(f"Unsupported OS: {os_name}")
     


### PR DESCRIPTION
The chrome_d_download.py script was failing to fetch the correct Chrome version due to incorrect version handling logic. Updated the get_download_version method.

Closes #17, #16